### PR TITLE
fix: resolve esbuild security vulnerability and TypeScript errors

### DIFF
--- a/agents/ui/logger.ts
+++ b/agents/ui/logger.ts
@@ -51,7 +51,7 @@ export class RichLogger {
   header(text: string, useGradient: boolean = true): void {
     console.log('');
     if (useGradient) {
-      const gradientText = gradient(theme.colors.gradient)(text);
+      const gradientText = gradient(...theme.colors.gradient)(text);
       console.log(chalk.bold(gradientText));
     } else {
       console.log(chalk.hex(theme.colors.primary).bold(text));
@@ -231,7 +231,7 @@ export class RichLogger {
   /**
    * ASCII art banner
    */
-  banner(text: string, font: string = 'Standard'): void {
+  banner(text: string, font: string = 'Standard'): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       figlet.text(
         text,
@@ -245,7 +245,7 @@ export class RichLogger {
             reject(err);
             return;
           }
-          const gradientText = gradient(theme.colors.gradient)(data || '');
+          const gradientText = gradient(...theme.colors.gradient)(data || '');
           console.log(gradientText);
           resolve();
         }
@@ -257,7 +257,7 @@ export class RichLogger {
    * Gradient text
    */
   gradient(text: string): void {
-    const gradientText = gradient(theme.colors.gradient)(text);
+    const gradientText = gradient(...theme.colors.gradient)(text);
     console.log(gradientText);
   }
 

--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
   "devDependencies": {
     "@anthropic-ai/claude-code": "^2.0.9",
     "@types/figlet": "^1.5.8",
+    "@types/gradient-string": "^1.1.6",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "@typescript-eslint/parser": "^6.13.0",
     "eslint": "^8.54.0",
     "tsx": "^4.7.0",
     "typescript": "^5.8.3",
-    "vitest": "^1.0.0"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",

--- a/scripts/agentic.ts
+++ b/scripts/agentic.ts
@@ -11,7 +11,6 @@
 
 import { logger, theme } from '../agents/ui/index.js';
 import { execSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
 import * as readline from 'readline/promises';
 
 const rl = readline.createInterface({


### PR DESCRIPTION
## 概要
Issue #8 で報告された esbuild のセキュリティ脆弱性と TypeScript エラーを修正します。

## 変更内容

### セキュリティ修正 🔒
- **vitest を 3.2.4 にアップデート**
  - esbuild 脆弱性 [GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99) を解決
  - npm audit で検出された4件の中程度の脆弱性を修正

### TypeScript 修正 🔧
- `@types/gradient-string` を devDependencies に追加
- `agents/ui/logger.ts`:
  - gradient 関数呼び出しをスプレッド構文に修正 (`gradient(...theme.colors.gradient)`)
  - `banner()` の返り値の型を `Promise<void>` に修正
- `scripts/agentic.ts`:
  - 未使用の fs インポートを削除

## テスト結果 ✅
```bash
✓ npm run typecheck - 型エラーなし
✓ npm test - 全テストパス (6/6)
```

## 破壊的変更
vitest のメジャーバージョンアップ (v1.0.0 → v3.2.4) が含まれますが、既存のテストは全て正常に動作することを確認済みです。

## 関連 Issue
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)